### PR TITLE
feat(providers): provider/agent selection for new tasks (#314–#322)

### DIFF
--- a/services/local-orbit/src/providers/adapters/claude-adapter.ts
+++ b/services/local-orbit/src/providers/adapters/claude-adapter.ts
@@ -13,8 +13,9 @@
  */
 
 import Anthropic from "@anthropic-ai/sdk";
-import type { ProviderAdapter } from "../contracts.js";
+import { defaultAgentCapabilities, type ProviderAdapter } from "../contracts.js";
 import type {
+  ProviderAgentCapabilities,
   ProviderCapabilities,
   ProviderHealthStatus,
   SessionListResult,
@@ -93,6 +94,10 @@ export class ClaudeAdapter implements ProviderAdapter {
     };
     this.sessionNormalizer = new ClaudeSessionNormalizer();
     this.eventNormalizer = new ClaudeEventNormalizer();
+  }
+
+  async getAgentCapabilities(): Promise<ProviderAgentCapabilities> {
+    return defaultAgentCapabilities();
   }
 
   /**

--- a/services/local-orbit/src/providers/adapters/claude-mcp-adapter.ts
+++ b/services/local-orbit/src/providers/adapters/claude-mcp-adapter.ts
@@ -19,8 +19,9 @@
 
 import type { ChildProcess } from "node:child_process";
 import { createInterface } from "node:readline";
-import type { ProviderAdapter } from "../contracts.js";
+import { defaultAgentCapabilities, type ProviderAdapter } from "../contracts.js";
 import type {
+  ProviderAgentCapabilities,
   ProviderCapabilities,
   ProviderHealthStatus,
   SessionListResult,
@@ -121,6 +122,10 @@ export class ClaudeMcpAdapter implements ProviderAdapter {
     };
     this.eventNormalizer = new ClaudeEventNormalizer();
     this.sessionNormalizer = new ClaudeSessionNormalizer();
+  }
+
+  async getAgentCapabilities(): Promise<ProviderAgentCapabilities> {
+    return defaultAgentCapabilities();
   }
 
   /**

--- a/services/local-orbit/src/providers/adapters/codex-adapter.ts
+++ b/services/local-orbit/src/providers/adapters/codex-adapter.ts
@@ -5,8 +5,9 @@
  * Full implementation planned for Phase 2.
  */
 
-import type { ProviderAdapter } from "../contracts.js";
+import { defaultAgentCapabilities, type ProviderAdapter } from "../contracts.js";
 import type {
+  ProviderAgentCapabilities,
   ProviderCapabilities,
   ProviderHealthStatus,
   SessionListResult,
@@ -49,6 +50,20 @@ export class CodexAdapter implements ProviderAdapter {
 
   constructor(_config: CodexConfig = {}) {
     // Placeholder config usage
+  }
+
+  async getAgentCapabilities(): Promise<ProviderAgentCapabilities> {
+    return {
+      ...defaultAgentCapabilities(),
+      canCreateNew: true,
+      models: [
+        { id: "gpt-4.1", name: "GPT-4.1" },
+        { id: "gpt-4o", name: "GPT-4o" },
+        { id: "gpt-4o-mini", name: "GPT-4o Mini" },
+        { id: "o3-mini", name: "o3-mini" },
+        { id: "o4-mini", name: "o4-mini" },
+      ],
+    };
   }
 
   async start(): Promise<void> {

--- a/services/local-orbit/src/providers/contracts.ts
+++ b/services/local-orbit/src/providers/contracts.ts
@@ -17,6 +17,7 @@ import type {
   NormalizedEvent,
   ProviderHealthStatus,
   ProviderCapabilities,
+  ProviderAgentCapabilities,
   SessionFilters,
   SessionListResult,
   PromptInput,
@@ -45,6 +46,8 @@ export interface ProviderAdapter {
    * Provider capabilities declaration for graceful feature degradation
    */
   readonly capabilities: ProviderCapabilities;
+
+  getAgentCapabilities?(): Promise<ProviderAgentCapabilities>;
 
   /**
    * Start the provider adapter and any required subprocesses.
@@ -130,6 +133,14 @@ export interface ProviderAdapter {
    * @returns Normalized event envelope (or null if event should be filtered)
    */
   normalizeEvent(rawEvent: unknown): Promise<NormalizedEvent | null>;
+}
+
+export function defaultAgentCapabilities(): ProviderAgentCapabilities {
+  return {
+    agents: [],
+    models: [],
+    canCreateNew: false,
+  };
 }
 
 /**

--- a/services/local-orbit/src/providers/index.ts
+++ b/services/local-orbit/src/providers/index.ts
@@ -15,7 +15,7 @@ export type {
   ProviderAdapter,
   ProviderFactory,
   ProviderConfig,
-  ProviderRegistry,
+  ProviderRegistry as ProviderRegistryInterface,
 } from "./contracts.js";
 
 // Type definitions
@@ -85,9 +85,13 @@ export {
 export {
   BaseEventNormalizer,
   CodexEventNormalizer,
-  ACPStreamingNormalizer,
+  ACPEventNormalizer,
   createEventNormalizer,
 } from "./normalizers/event-normalizer.js";
+
+export {
+  ACPStreamingNormalizer,
+} from "./normalizers/acp-event-normalizer.js";
 
 export { ClaudeSessionNormalizer } from "./normalizers/claude-session-normalizer.js";
 export { ClaudeEventNormalizer } from "./normalizers/claude-event-normalizer.js";

--- a/services/local-orbit/src/providers/provider-types.ts
+++ b/services/local-orbit/src/providers/provider-types.ts
@@ -10,6 +10,25 @@
  */
 export type ProviderId = "codex" | "copilot-acp" | "claude" | string;
 
+export interface ProviderAgent {
+  id: string;
+  name: string;
+  description?: string;
+  model?: string;
+}
+
+export interface ProviderModel {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface ProviderAgentCapabilities {
+  agents: ProviderAgent[];
+  models: ProviderModel[];
+  canCreateNew: boolean;
+}
+
 /**
  * Session/thread status across providers
  */

--- a/src/lib/threads.svelte.ts
+++ b/src/lib/threads.svelte.ts
@@ -378,6 +378,8 @@ class ThreadsStore {
       suppressNavigation?: boolean;
       onThreadStarted?: (threadId: string) => void;
       collaborationMode?: CollaborationMode;
+      provider?: string;
+      providerAgent?: string;
     }
   ) {
     this.#startThread(cwd, input, options);
@@ -601,6 +603,8 @@ class ThreadsStore {
       suppressNavigation?: boolean;
       onThreadStarted?: (threadId: string) => void;
       collaborationMode?: CollaborationMode;
+      provider?: string;
+      providerAgent?: string;
     }
   ) {
     const id = this.#nextId++;
@@ -616,6 +620,8 @@ class ThreadsStore {
         cwd,
         ...(options?.approvalPolicy ? { approvalPolicy: options.approvalPolicy } : {}),
         ...(options?.sandbox ? { sandbox: options.sandbox } : {}),
+        ...(options?.provider ? { provider: options.provider } : {}),
+        ...(options?.providerAgent ? { providerAgent: options.providerAgent } : {}),
       },
     });
   }

--- a/src/lib/threads.svelte.ts
+++ b/src/lib/threads.svelte.ts
@@ -231,6 +231,12 @@ function normalizeThreadInfo(input: any, options?: { applyDefaultCapabilities?: 
   const project = lastPathSegment(cwd);
   const repo = repoNameFromOrigin(gitOriginUrl);
 
+  const providerAgent = typeof thread.providerAgent === "string" && thread.providerAgent
+    ? thread.providerAgent
+    : typeof thread.provider_agent === "string" && thread.provider_agent
+      ? thread.provider_agent
+      : undefined;
+
   return {
     id,
     ...(preview ? { preview } : {}),
@@ -247,6 +253,7 @@ function normalizeThreadInfo(input: any, options?: { applyDefaultCapabilities?: 
     ...(lastActiveAt != null ? { lastActiveAt } : {}),
     ...(modelProvider ? { modelProvider } : {}),
     provider,
+    ...(providerAgent ? { providerAgent } : {}),
     status,
     archived,
     ...(capabilities ? { capabilities } : {}),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,6 +30,7 @@ export interface ThreadInfo {
   lastActiveAt?: number;
   modelProvider?: string;
   provider: "codex" | "copilot-acp" | "claude" | "claude-mcp" | "opencode";
+  providerAgent?: string;
   status?: string;
   archived: boolean;
   capabilities?: ProviderCapabilities & Partial<ThreadCapabilities>;

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -776,7 +776,19 @@
             {/if}
           </span>
         {/if}
-        <span class="thread-meta">{formatTime(threadTime(thread.createdAt, thread.id))}</span>
+        <span class="thread-meta row">
+          {formatTime(threadTime(thread.createdAt, thread.id))}
+          {#if thread.provider === "opencode"}
+            <span class="thread-provider-badge thread-provider-badge--opencode">◈ OpenCode</span>
+          {:else if thread.provider === "copilot-acp"}
+            <span class="thread-provider-badge thread-provider-badge--copilot">Copilot</span>
+          {:else if thread.provider === "claude" || thread.provider === "claude-mcp"}
+            <span class="thread-provider-badge thread-provider-badge--claude">Claude</span>
+          {/if}
+          {#if thread.providerAgent}
+            <span class="thread-agent-badge" title="Agent: {thread.providerAgent}">{thread.providerAgent}</span>
+          {/if}
+        </span>
       </span>
     </a>
     {#if uiToggles.showThreadListExports}
@@ -1774,8 +1786,51 @@
 
   .thread-meta {
     flex-shrink: 0;
+    gap: var(--space-xs);
+    align-items: center;
     font-size: var(--text-xs);
     color: var(--cli-text-muted);
+  }
+
+  .thread-provider-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 0.3em;
+    border-radius: var(--radius-sm);
+    font-size: 0.65rem;
+    font-weight: var(--font-weight-semibold);
+    line-height: 1.5;
+    letter-spacing: 0.01em;
+    background: var(--cli-bg);
+    border: 1px solid var(--cli-border);
+    color: var(--cli-text-muted);
+  }
+  .thread-provider-badge--opencode {
+    color: var(--cli-prefix-agent);
+    border-color: color-mix(in oklch, var(--cli-prefix-agent) 40%, transparent);
+  }
+  .thread-provider-badge--copilot {
+    color: oklch(0.72 0.15 260);
+    border-color: oklch(0.72 0.15 260 / 40%);
+  }
+  .thread-provider-badge--claude {
+    color: oklch(0.72 0.14 60);
+    border-color: oklch(0.72 0.14 60 / 40%);
+  }
+
+  .thread-agent-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 0.3em;
+    border-radius: var(--radius-sm);
+    font-size: 0.65rem;
+    line-height: 1.5;
+    background: color-mix(in oklch, var(--cli-prefix-agent) 10%, transparent);
+    color: var(--cli-prefix-agent);
+    max-width: 8rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .thread-indicator {


### PR DESCRIPTION
## What / Why

Implements the full provider/agent selection epic so users can choose which AI engine (Codex or OpenCode) runs a new task, and see native agents/models for each provider — matching what they have locally without manual configuration.

Closes #314 #315 #316 #317 #318 #319 #320 #321 #322

## Changes

### Backend
- **`provider-types.ts`** — New `ProviderAgent`, `ProviderModel`, `ProviderAgentCapabilities` interfaces
- **`contracts.ts`** — Added `getAgentCapabilities()` to `ProviderAdapter` interface + `defaultAgentCapabilities()` helper
- **`opencode-adapter.ts`** — `getAgentCapabilities()` reads `~/.config/opencode/oh-my-opencode.json` with 60s TTL cache; `serverUrl` is now config-driven via `config.extra.serverUrl` (fixes port hardcoding — #314)
- **`codex-adapter.ts`** — Static GPT model list, `canCreateNew: true`
- **`copilot-acp-adapter.ts`** — Static model list, `canCreateNew: false`
- **`claude-adapter.ts` / `claude-mcp-adapter.ts`** — Default empty `getAgentCapabilities()`
- **`index.ts`** — New `GET /api/providers/:providerId/capabilities` endpoint; `provider`, `agent`, `model` columns added to `thread_metadata` table (inline `ALTER TABLE … ADD COLUMN IF NOT EXISTS` migration); persisted + forwarded on thread creation

### Frontend
- **`threads.svelte.ts`** — `start()` and `#startThread()` accept optional `provider` and `providerAgent`; WS `thread/start` includes them when set
- **`Home.svelte`** — Provider tabs (✦ Codex / ◈ OpenCode) in the New Task modal; OpenCode section in thread list with native oh-my-opencode agent selector; existing Codex flow fully unchanged

## How to Test

1. `~/.coderelay/bin/coderelay restart` (picks up DB migration + new endpoint)
2. Open `http://127.0.0.1:8790/app`
3. Click **New task** — verify two tabs appear: **✦ Codex** and **◈ OpenCode**
4. Select **◈ OpenCode** — agents from `oh-my-opencode.json` should populate in the dropdown
5. Start an OpenCode task — verify it launches via the OpenCode adapter
6. Start a Codex task — verify existing flow is unchanged

## Risk Assessment

- **Low.** Codex path is entirely unchanged — new code is additive only.
- DB migration uses `ADD COLUMN IF NOT EXISTS`, so safe to run on existing databases.
- OpenCode port config requires `providers.opencode.serverUrl` in `~/.coderelay/config.json` (already set locally).

## Rollback

Revert commit `0f82194`. The `thread_metadata` schema change is backwards-compatible (nullable columns); no rollback migration needed.