### PR TITLE
feat(tool): render file diffs with PierreDiff and show +N −N badge

### DIFF
--- a/.bundlesize.baseline.json
+++ b/.bundlesize.baseline.json
@@ -18,6 +18,8 @@
     "NewTask.js": 3174,
     "Pair.css": 564,
     "Pair.js": 1616,
+    "PierreDiff.css": 119,
+    "PierreDiff.js": 1484,
     "ProjectPicker.css": 2430,
     "ProjectPicker.js": 2582,
     "Review.css": 3281,
@@ -290,5 +292,5 @@
     "zig.js": 5340
   },
   "generatedAt": "2026-02-21T16:53:09.560775Z",
-  "total": 10181498
+  "total": 10183101
 }

--- a/src/lib/components/Tool.svelte
+++ b/src/lib/components/Tool.svelte
@@ -4,6 +4,7 @@
   import { marked } from "marked";
   import DOMPurify from "dompurify";
   import { uiToggles } from "../uiToggles.svelte";
+  import PierreDiff from "./PierreDiff.svelte";
   import { fade } from "svelte/transition";
 
   interface Props {
@@ -305,6 +306,14 @@
       <span class="opacity-90">{statusConfig.label}</span>
     </span>
 
+    {#if message.kind === 'file' && (message.metadata?.linesAdded || message.metadata?.linesRemoved)}
+      <span class="flex shrink-0 items-center gap-xs text-xs font-mono ml-xs">
+        {#if message.metadata?.linesAdded}<span class="text-cli-success">+{message.metadata.linesAdded}</span>{/if}
+        {#if message.metadata?.linesRemoved}<span class="text-cli-error">−{message.metadata.linesRemoved}</span>{/if}
+        <span class="text-cli-text-muted">modified</span>
+      </span>
+    {/if}
+
     {#if hasContent}
       <svg
         class="h-4 w-4 shrink-0 text-cli-text-dim transition-transform duration-200"
@@ -322,7 +331,7 @@
     {#if hasContent && uiToggles.showToolOutputCopy}
       <button
         type="button"
-        class="absolute right-2.5 top-2 z-[1] cursor-pointer rounded-sm border border-cli-border bg-black/25 px-sm py-1 font-mono text-2xs text-cli-text-muted opacity-0 shadow-none transition-all duration-150 hover:text-cli-text group-hover:opacity-100 group-focus-within:opacity-100 max-[520px]:px-3 max-[520px]:py-1.5 max-[520px]:text-xs max-[520px]:opacity-100 {copyState === 'copied' ? 'border-cli-success text-cli-success !opacity-100' : ''} {copyState === 'error' ? 'border-cli-error text-cli-error !opacity-100' : ''}"
+        class="absolute right-2.5 top-2 z-[1] cursor-pointer rounded-sm border border-cli-border bg-black/25 px-sm py-1 font-mono text-2xs text-cli-text-muted opacity-0 shadow-none transition-all duration-150 hover:text-cli-text group-hover:opacity-100 group-focus-within:opacity-100 max-sm:hidden {copyState === 'copied' ? 'border-cli-success text-cli-success !opacity-100' : ''} {copyState === 'error' ? 'border-cli-error text-cli-error !opacity-100' : ''}"
         onclick={(e) => {
           e.stopPropagation();
           copyToolOutput();
@@ -340,7 +349,7 @@
       {#if renderMarkdown}
         <div class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim markdown">{@html renderedToolHtml}</div>
       {:else}
-        <pre class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim">{toolInfo.content}</pre>
+        {#if message.kind === 'file'}<PierreDiff diff={toolInfo.content} />{:else}<pre class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim">{toolInfo.content}</pre>{/if}
       {/if}
     </div>
   {/if}


### PR DESCRIPTION
## Summary

- Use the existing `PierreDiff` component to render file-kind tool output with proper diff highlighting instead of raw `<pre>` text
- Add `+N −N modified` badge in the file tool header, sourced from `message.metadata.linesAdded` / `linesRemoved`
- Hide the copy button on small screens with `max-sm:hidden` for consistency

## What / Why

File diffs shown inside tool messages were rendered as plain preformatted text, losing the color-coded diff view that `PierreDiff` already provides elsewhere in the app. This change reuses that component so file changes are immediately scannable with added/removed line highlighting. The `+N −N` badge gives a quick at-a-glance summary without expanding the tool output.

## How to Test

1. Start the app and open a thread that contains file-change tool messages
2. Expand a file tool — verify the diff renders with green/red line highlighting via PierreDiff
3. Check the collapsed header shows `+N −N modified` when metadata is present
4. Resize browser to mobile width — confirm the copy button hides on small screens

## Risk Assessment

**Low.** Uses an existing, tested component (`PierreDiff`) with no new dependencies. The badge is purely additive and guarded by metadata presence checks.

## Rollback

Revert this single commit — no migrations or config changes involved.