### PR TITLE
fix(home): aria-expanded on filter toggle, extract PROVIDER_DISPLAY_NAMES constant

### DIFF
--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -101,6 +101,13 @@
     },
   } as const;
 
+  const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+    "codex": "Codex",
+    "copilot-acp": "Copilot",
+    "claude": "Claude",
+    "opencode": "OpenCode",
+  };
+
   let showTaskModal = $state(false);
   let taskNote = $state("");
   let taskProject = $state("");
@@ -970,14 +977,14 @@
       </div>
 
       <div class="filter-row row">
-        <button class="filter-toggle" type="button" onclick={() => (filtersExpanded = !filtersExpanded)}>
+        <button class="filter-toggle" type="button" onclick={() => (filtersExpanded = !filtersExpanded)} aria-expanded={filtersExpanded}>
           <span class="filter-toggle-caret">{filtersExpanded ? '▾' : '▸'}</span>
           Filters
         </button>
         {#if !filtersExpanded && (filters.provider !== "all" || filters.status !== "all")}
           <span class="filter-summary row">
             {#if filters.provider !== "all"}
-              <span class="filter-active-chip">{filters.provider === "codex" ? "Codex" : filters.provider === "copilot-acp" ? "Copilot" : filters.provider === "claude" ? "Claude" : "OpenCode"}</span>
+              <span class="filter-active-chip">{PROVIDER_DISPLAY_NAMES[filters.provider] ?? filters.provider}</span>
             {/if}
             {#if filters.status !== "all"}
               <span class="filter-active-chip">{filters.status === "active" ? "Active" : "Archived"}</span>


### PR DESCRIPTION
## Summary
- Adds `aria-expanded` attribute to the collapsible filter toggle button for screen reader / a11y compliance (#333)
- Extracts `PROVIDER_DISPLAY_NAMES` constant to replace inline ternary chains with a clean lookup map (#334)
- Filter tab visibility guards and filter reset logic were already correct in main; confirmed no regression (#332)

## How to test
1. Open thread list, click the ▸ Filters toggle — inspect element and confirm `aria-expanded` toggles `true`/`false`
2. Apply a provider filter, collapse filters — confirm the active chip label uses the new lookup (e.g. "Copilot" not "copilot-acp")
3. Run `VITE_ZANE_LOCAL=1 bunx --bun vite build` — should pass cleanly

## Risk assessment
Low. Template-only changes: one new constant, one new attribute, one expression replacement. No logic change.

## Rollback
`git revert` the single commit on this branch.

Closes #332
Closes #333
Closes #334