### PR TITLE
fix(messages): unify copy button mobile breakpoint to max-sm:hidden

### DIFF
--- a/src/lib/components/MessageBlock.svelte
+++ b/src/lib/components/MessageBlock.svelte
@@ -244,7 +244,7 @@
   {#if uiToggles.showMessageCopyButton}
     <button
       type="button"
-      class="absolute top-[6px] right-[10px] px-2.5 py-1 rounded-sm border border-cli-border text-cli-text-muted font-mono text-2xs cursor-pointer opacity-0 transition-all duration-200 hover:text-cli-text max-[520px]:opacity-100 max-[520px]:px-3 max-[520px]:py-1.5 max-[520px]:text-xs group-hover:opacity-100 focus-within:opacity-100"
+      class="absolute top-[6px] right-[10px] px-2.5 py-1 rounded-sm border border-cli-border text-cli-text-muted font-mono text-2xs cursor-pointer opacity-0 transition-all duration-200 hover:text-cli-text max-sm:hidden group-hover:opacity-100 focus-within:opacity-100"
       style="background-color: var(--bg-overlay)"
       aria-label="Copy message"
       class:opacity-100={copyState !== "idle"}


### PR DESCRIPTION
## Summary
- Replaces the inconsistent `max-[520px]` breakpoints on the standalone copy button in `MessageBlock.svelte` with `max-sm:hidden` (640px) to match `MessageActions.svelte` and `Tool.svelte`

## How to test
1. Load the app on a screen narrower than 640px — the copy button should be hidden (matching Tool.svelte behavior)
2. Load on a screen wider than 640px — copy button visible on hover as before
3. Run `VITE_ZANE_LOCAL=1 bunx --bun vite build` — passes cleanly

## Risk assessment
Very low. Single class string change on one button in one component.

## Rollback
`git revert` the single commit on this branch.

Closes #336