### PR TITLE
fix(messages): PierreDiff scroll constraint + populate linesAdded/linesRemoved badge metadata

### DIFF
--- a/src/lib/components/Tool.svelte
+++ b/src/lib/components/Tool.svelte
@@ -349,7 +349,7 @@
       {#if renderMarkdown}
         <div class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim markdown">{@html renderedToolHtml}</div>
       {:else}
-        {#if message.kind === 'file'}<PierreDiff diff={toolInfo.content} />{:else}<pre class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim">{toolInfo.content}</pre>{/if}
+        {#if message.kind === 'file'}<div class="max-h-[300px] overflow-y-auto"><PierreDiff diff={toolInfo.content} /></div>{:else}<pre class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim">{toolInfo.content}</pre>{/if}
       {/if}
     </div>
   {/if}

--- a/src/lib/messages.svelte.ts
+++ b/src/lib/messages.svelte.ts
@@ -27,6 +27,15 @@ interface ReasoningState {
   header: string | null;
 }
 
+function countDiffLines(text: string): { linesAdded: number; linesRemoved: number } {
+  let linesAdded = 0;
+  let linesRemoved = 0;
+  for (const line of text.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("++")) linesAdded++;
+    else if (line.startsWith("-") && !line.startsWith("--")) linesRemoved++;
+  }
+  return { linesAdded, linesRemoved };
+}
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
 }
@@ -1176,7 +1185,8 @@ class MessagesStore {
         case "fileChange": {
           const changes = item.changes as Array<{ path: string; diff?: string }>;
           const text = changes?.map((c) => `${c.path}\n${c.diff || ""}`).join("\n\n") || "";
-          this.#upsert(threadId, { id: itemId, role: "tool", kind: "file", text, threadId });
+          const { linesAdded, linesRemoved } = countDiffLines(text);
+          this.#upsert(threadId, { id: itemId, role: "tool", kind: "file", text, threadId, metadata: { linesAdded, linesRemoved } });
           this.#clearStreaming(threadId, itemId);
           return;
         }
@@ -1361,6 +1371,11 @@ class MessagesStore {
               kind: "file",
               text: changes?.map((c) => `${c.path}\n${c.diff || ""}`).join("\n\n") || "",
               threadId,
+              metadata: (() => {
+                const t = changes?.map((c) => `${c.path}\n${c.diff || ""}`).join("\n\n") || "";
+                const { linesAdded, linesRemoved } = countDiffLines(t);
+                return { linesAdded, linesRemoved };
+              })(),
             });
             break;
           }


### PR DESCRIPTION
## Summary
- Wraps `<PierreDiff>` in `Tool.svelte` with `max-h-[300px] overflow-y-auto` so large diffs are scroll-constrained, matching the `<pre>` sibling (#335)
- Adds `countDiffLines()` helper in `messages.svelte.ts` that parses unified diff text to count `+`/`-` lines
- Populates `metadata.linesAdded` and `metadata.linesRemoved` at both file-kind message construction sites (live streaming path + `rehydrateFromEvents` history path) so the existing `+N/−N` badge in the diff header now renders correctly (#335)

## How to test
1. Open a Codex thread with a file change tool call — the diff should be scroll-constrained to 300px max height
2. The header badge should show e.g. `+12 −4 modified`
3. Reload the thread — badge should persist (populated in rehydration path too)
4. Run `VITE_ZANE_LOCAL=1 bunx --bun vite build` — passes cleanly

## Risk assessment
Low-medium. `countDiffLines` is a simple line-scan with no external deps. The IIFE in `rehydrateFromEvents` is slightly verbose but avoids adding a local variable to the switch block scope.

## Rollback
`git revert` the single commit on this branch.

Closes #335