### PR TITLE
docs: update quad-provider support in README, ARCHITECTURE, and DIFFERENCES_FROM_ZANE

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Filter your thread list with dual-axis filtering:
 - `all` (default): Show all threads
 - `codex`: Show Codex threads only
 - `copilot-acp`: Show Copilot ACP sessions only
+- `opencode`: Show OpenCode sessions only
+- `claude`: Show Claude sessions only
 
 **Status Filter:**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,10 +63,10 @@ CodeRelay supports multiple AI provider backends through a unified adapter inter
 │  │   - Adapter lookup                            │  │
 │  └───┬───────────────────────────────────────┬───┘  │
 │      │                                       │      │
-│  ┌───▼──────────┐ ┌──────────▼───────┐ ┌──────▼────────┐ │
-│  │CodexAdapter │ │ OpenCodeAdapter   │ │CopilotACP     │ │
-│  │(via Anchor) │ │ (REST API)        │ │Adapter        │ │
-│  └───┬──────────┘ └───────────────────┘ └───────┬────┘ │
+|  ┌───▼──────────┐ ┌──────────▼───────┐ ┌──────▼────────┐ ┌──────▼────────┐ |
+|  │CodexAdapter │ │ OpenCodeAdapter   │ │CopilotACP     │ │ClaudeAdapter  │ |
+|  │(via Anchor) │ │ (REST API)        │ │Adapter        │ │(REST API)     │ |
+|  └───┬──────────┘ └───────────────────┘ └───────┬────┘ └───────────────┘ |
 │      │                                       │      │
 └──────┼───────────────────────────────────────┼──────┘
        │                                       │

--- a/docs/DIFFERENCES_FROM_ZANE.md
+++ b/docs/DIFFERENCES_FROM_ZANE.md
@@ -34,12 +34,12 @@ CodeRelay’s goal is narrower and more opinionated:
 
 **Current Provider Matrix:**
 
-| Capability | Codex | Copilot ACP |
-|------------|-------|-------------|
-| `CAN_ATTACH_FILES` | ✅ | ✅ |
-| `CAN_FILTER_HISTORY` | ✅ | ❌ |
-| `SUPPORTS_APPROVALS` | ✅ | ✅ (dynamic) |
-| `SUPPORTS_STREAMING` | ✅ | ✅ |
+| Capability | Codex | Copilot ACP | OpenCode | Claude |
+|------------|-------|-------------|----------|--------|
+| `CAN_ATTACH_FILES` | ✅ | ✅ | ❌ | ❌ |
+| `CAN_FILTER_HISTORY` | ✅ | ❌ | ❌ | ❌ |
+| `SUPPORTS_APPROVALS` | ✅ | ✅ (dynamic) | ❌ | ❌ |
+| `SUPPORTS_STREAMING` | ✅ | ✅ | ✅ | ✅ |
 
 **Benefits:**
 


### PR DESCRIPTION
## Summary
- **README.md**: Adds `opencode` and `claude` to the Provider Filter documentation so all four filter values are listed (#325)
- **docs/ARCHITECTURE.md**: Updates the provider adapter ASCII diagram to include the Claude adapter box alongside Codex, OpenCode, and Copilot ACP (#325)
- **docs/DIFFERENCES_FROM_ZANE.md**: Expands the capability matrix table to include OpenCode and Claude columns (#325)

## How to test
1. Review the three updated docs for accuracy
2. Run `VITE_ZANE_LOCAL=1 bunx --bun vite build` — passes cleanly (docs-only change)

## Risk assessment
None. Documentation-only change.

## Rollback
`git revert` the single commit on this branch.

Closes #325