### PR TITLE
Align provider docs and diff rendering

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ Responsibilities:
 
 ## Provider Abstraction Layer
 
-CodeRelay supports multiple AI provider backends through a unified adapter interface. This enables viewing and interacting with sessions from different providers (Codex, OpenCode, GitHub Copilot+, Claude, etc.) in one UI.
+CodeRelay supports multiple AI provider backends through a unified adapter interface. This enables viewing and interacting with sessions from Codex, OpenCode, GitHub Copilot (ACP), and Claude adapters in one UI.
 
 ### Architecture
 
@@ -63,17 +63,16 @@ CodeRelay supports multiple AI provider backends through a unified adapter inter
 │  │   - Adapter lookup                            │  │
 │  └───┬───────────────────────────────────────┬───┘  │
 │      │                                       │      │
-|  ┌───▼──────────┐ ┌──────────▼───────┐ ┌──────▼────────┐ ┌──────▼────────┐ |
-|  │CodexAdapter │ │ OpenCodeAdapter   │ │CopilotACP     │ │ClaudeAdapter  │ |
-|  │(via Anchor) │ │ (REST API)        │ │Adapter        │ │(REST API)     │ |
-|  └───┬──────────┘ └───────────────────┘ └───────┬────┘ └───────────────┘ |
-│      │                                       │      │
-└──────┼───────────────────────────────────────┼──────┘
-       │                                       │
-   ┌───▼────┐                          ┌──────▼─────┐
-   │ anchor │                          │ gh copilot │
-   │(Codex) │                          │   --acp    │
-   └────────┘                          └────────────┘
+│  ┌───▼──────────┐ ┌──────────▼───────┐ ┌──────▼────────┐ ┌──────▼────────┐ │
+│  │ CodexAdapter │ │ OpenCodeAdapter  │ │ CopilotACP    │ │ ClaudeAdapter │ │
+│  │ (via Anchor) │ │ (REST API)       │ │ Adapter       │ │ (REST/MCP)    │ │
+│  └───┬──────────┘ └──────────┬───────┘ └───────┬───────┘ └────────┬───────┘ │
+└──────┼───────────────────────┼─────────────────┼──────────────────┼─────────┘
+       │                       │                 │                  │
+   ┌───▼────┐          ┌───────▼──────┐   ┌──────▼─────┐    ┌──────▼─────┐
+   │ anchor │          │ opencode     │   │ gh copilot │    │ Anthropic/ │
+   │(Codex) │          │ serve        │   │   --acp    │    │ Claude CLI │
+   └────────┘          └──────────────┘   └────────────┘    └────────────┘
 ```
 
 ### ProviderAdapter Contract
@@ -117,7 +116,7 @@ interface NormalizedSession {
 1. **Startup**: `ProviderRegistry.startAll()` called during server initialization
 2. **Shutdown**: `ProviderRegistry.stopAll()` called on SIGTERM/SIGINT
 3. **Thread List**: `augmentThreadList()` fetches sessions from all providers and merges
-4. **Read-Only Enforcement**: `isAcpWriteOperation()` blocks writes to non-Codex providers in Phase 1
+4. **ACP Write Constraints**: `isAcpWriteOperation()` restricts unsupported writes on `copilot-acp:` threads; OpenCode and Claude prompts use generic provider routing
 5. **Health Checks**: `/admin/health` endpoint aggregates provider health
 
 ### Provider Adapters
@@ -134,7 +133,7 @@ CodeRelay implements five provider adapters:
 
 - **Connection**: REST API to local OpenCode server (default: `http://127.0.0.1:4096`)
 - **Communication**: HTTP REST
-- **Full Capabilities**: Send prompts, stream responses, attachments support
+- **Current Capabilities**: Send prompts and stream responses; attachments are not supported
 
 #### CopilotAcpAdapter
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -10,21 +10,21 @@ CodeRelay uses a **provider adapter pattern** to support multiple AI backends. E
 
 - **Codex** (via Anchor): Full read/write support, all capabilities enabled
 - **OpenCode**: REST API integration with local OpenCode server
-- **GitHub Copilot+**: Full integration with send, streaming, approvals, and attachments
+- **GitHub Copilot (ACP)**: Full integration with send, streaming, approvals, and attachments
 - **Claude (Web API)**: Direct Anthropic Claude API integration
 - **Claude (MCP)**: Local Claude CLI via MCP
 
 ## Provider Capability Matrix
 
-| Capability | Codex | OpenCode | Copilot+ | Claude |
-|------------|-------|----------|-----------|--------|
-| `CAN_ATTACH_FILES` | ✅ | ✅ | ✅ | ❌ |
-| `CAN_FILTER_HISTORY` | ✅ | ✅ | ❌ | ✅ |
-| `SUPPORTS_APPROVALS` | ✅ | ✅ | ✅ (dynamic) | ❌ |
-| `SUPPORTS_STREAMING` | ✅ | ✅ | ✅ | ✅ |
+| Capability | Codex | OpenCode | Copilot ACP | Claude Web | Claude MCP |
+|------------|-------|----------|-------------|------------|------------|
+| `CAN_ATTACH_FILES` | ✅ | ❌ | ✅ | ✅ | ❌ |
+| `CAN_FILTER_HISTORY` | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `SUPPORTS_APPROVALS` | ✅ | ❌ | ✅ (dynamic) | ❌ | ❌ |
+| `SUPPORTS_STREAMING` | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 **Notes:** 
-- Copilot+ `SUPPORTS_APPROVALS` is `false` when started with `--allow-all-tools` flag (tools are auto-approved at provider level).
+- Copilot ACP `SUPPORTS_APPROVALS` is `false` when started with `--allow-all-tools` (tools are auto-approved at provider level).
 - OpenCode capabilities depend on the OpenCode server version and model used.
 
 ## Quick Start

--- a/src/lib/components/Tool.svelte
+++ b/src/lib/components/Tool.svelte
@@ -349,7 +349,7 @@
       {#if renderMarkdown}
         <div class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim markdown">{@html renderedToolHtml}</div>
       {:else}
-        {#if message.kind === 'file'}<div class="max-h-[300px] overflow-y-auto"><PierreDiff diff={toolInfo.content} /></div>{:else}<pre class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim">{toolInfo.content}</pre>{/if}
+        {#if message.kind === 'file'}<div class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim"><PierreDiff diff={toolInfo.content} /></div>{:else}<pre class="m-0 max-h-[300px] overflow-y-auto whitespace-pre-wrap break-words px-md py-sm text-xs leading-relaxed text-cli-text-dim">{toolInfo.content}</pre>{/if}
       {/if}
     </div>
   {/if}

--- a/src/lib/messages.svelte.ts
+++ b/src/lib/messages.svelte.ts
@@ -1365,17 +1365,15 @@ class MessagesStore {
 
           case "fileChange": {
             const changes = item.changes as Array<{ path: string; diff?: string }>;
+            const text = changes?.map((c) => `${c.path}\n${c.diff || ""}`).join("\n\n") || "";
+            const { linesAdded, linesRemoved } = countDiffLines(text);
             messages.push({
               id,
               role: "tool",
               kind: "file",
-              text: changes?.map((c) => `${c.path}\n${c.diff || ""}`).join("\n\n") || "",
+              text,
               threadId,
-              metadata: (() => {
-                const t = changes?.map((c) => `${c.path}\n${c.diff || ""}`).join("\n\n") || "";
-                const { linesAdded, linesRemoved } = countDiffLines(t);
-                return { linesAdded, linesRemoved };
-              })(),
+              metadata: { linesAdded, linesRemoved },
             });
             break;
           }

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { socket } from "../lib/socket.svelte";
   import { threads } from "../lib/threads.svelte";
-  import type { ThreadInfo, ThreadFilterState } from "../lib/types";
+  import type { ProviderFilter, ThreadInfo, ThreadFilterState } from "../lib/types";
   import { messages } from "../lib/messages.svelte";
   import { navigate } from "../router";
   import { models } from "../lib/models.svelte";
@@ -101,7 +101,7 @@
     },
   } as const;
 
-  const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  const PROVIDER_DISPLAY_NAMES: Record<Exclude<ProviderFilter, "all">, string> = {
     "codex": "Codex",
     "copilot-acp": "Copilot",
     "claude": "Claude",


### PR DESCRIPTION
## Summary
- align provider capability documentation and naming with the runtime capability matrix
- repair the four-adapter architecture diagram and current write-routing description
- restore consistent PierreDiff containment styles
- avoid duplicate file-diff construction and type provider display names against the provider union

## Verification
- `bun run type-check` (0 errors; 2 pre-existing unused-selector warnings)
- `bun run build`
- `bun test` (247 passing)